### PR TITLE
upgrade chromedriver to support maximize window on chrome 70+ version

### DIFF
--- a/packages/plugin-selenium-driver/package.json
+++ b/packages/plugin-selenium-driver/package.json
@@ -17,7 +17,7 @@
     "@types/deepmerge": "2.2.0",
     "@types/node": "10.5.6",
     "@types/webdriverio": "4.10.3",
-    "chromedriver": "2.41.0",
+    "chromedriver": "2.44.0",
     "deepmerge": "2.1.1",
     "selenium-server": "3.14.0",
     "webdriverio": "4.13.1"


### PR DESCRIPTION
The windowHandleMaximize method is not working on chrome 70+ version, and that in some cases will cause some elements not clickable which result in test failed. Here are a [related issue](https://github.com/webdriverio/webdriverio/issues/3043)!