### PR TITLE
Replaced request-promise, added gzip field to IHttpRequest

### DIFF
--- a/packages/http-api/package.json
+++ b/packages/http-api/package.json
@@ -17,9 +17,9 @@
     "@testring/types": "0.4.52",
     "@testring/utils": "0.4.52",
     "@types/node": "10.5.6",
-    "@types/request-promise": "4.1.42",
+    "@types/request-promise-native": "1.0.15",
     "@types/tough-cookie": "2.3.3",
-    "request-promise": "4.2.2",
+    "request-promise-native": "1.0.7",
     "tough-cookie": "2.4.3"
   }
 }

--- a/packages/http-api/src/request-function.ts
+++ b/packages/http-api/src/request-function.ts
@@ -1,6 +1,6 @@
 import { IHttpRequest, IHttpResponse } from '@testring/types';
 import { Response, jar } from 'request';
-import * as requestPromise from 'request-promise';
+import * as requestPromise from 'request-promise-native';
 
 const toString = c => c.toString();
 
@@ -43,6 +43,7 @@ export async function requestFunction(request: IHttpRequest): Promise<IHttpRespo
         timeout: request.timeout,
         headers: request.headers,
         json: request.json,
+        gzip: request.gzip,
         jar: cookieJar,
         resolveWithFullResponse: true,
     };

--- a/packages/types/src/http-api/structs.ts
+++ b/packages/types/src/http-api/structs.ts
@@ -24,6 +24,7 @@ export interface IHttpRequest {
     query?: IHttpQueryParameters;
     cookies?: Array<any>;
     resolveWithFullResponse?: boolean;
+    gzip?: boolean;
 }
 
 export interface IHttpRequestMessage {


### PR DESCRIPTION
Replaced `request-promise` with `request-promise-native` (Bluebird promises vs native js promises).
Added `gzip` field to IHttpRequest interface