### PR TITLE
Fix for error: 'Error: The gridProxyDetails command needs a proxyId t…

### DIFF
--- a/packages/plugin-selenium-driver/src/plugin/index.ts
+++ b/packages/plugin-selenium-driver/src/plugin/index.ts
@@ -333,12 +333,12 @@ export class SeleniumPlugin implements IBrowserProxyPlugin {
         }
     }
 
-    public async gridProxyDetails(applicant: string) {
+    public async gridProxyDetails(applicant: string, proxyId: string | number) {
         await this.createClient(applicant);
         const client = this.getBrowserClient(applicant);
 
         if (client) {
-            return this.wrapWithPromise(client.gridProxyDetails());
+            return this.wrapWithPromise(client.gridProxyDetails(proxyId));
         }
     }
 

--- a/packages/types/src/browser-proxy/index.ts
+++ b/packages/types/src/browser-proxy/index.ts
@@ -26,7 +26,7 @@ export interface IBrowserProxyPlugin {
 
     click(applicant: string, selector: string): Promise<any>;
 
-    gridProxyDetails(applicant: string): Promise<any>;
+    gridProxyDetails(applicant: string, proxyId: string | number): Promise<any>;
 
     url(applicant: string, val: string): Promise<any>;
 

--- a/packages/web-application/src/web-client.ts
+++ b/packages/web-application/src/web-client.ts
@@ -62,8 +62,8 @@ export class WebClient implements IWebApplicationClient {
         return this.makeRequest(BrowserProxyActions.click, [xpath]);
     }
 
-    public gridProxyDetails() {
-        return this.makeRequest(BrowserProxyActions.gridProxyDetails, []);
+    public gridProxyDetails(proxyId) {
+        return this.makeRequest(BrowserProxyActions.gridProxyDetails, [proxyId]);
     }
 
     public url(val) {


### PR DESCRIPTION
Fix for 'Error: The gridProxyDetails command needs a proxyId to work with.'
In the previous request pool, I made a mistake. This will fix the error.