### PR TITLE
WAT-3825 - Pass full response on non 2xx response codes

### DIFF
--- a/core/types/src/http-api/structs.ts
+++ b/core/types/src/http-api/structs.ts
@@ -23,6 +23,7 @@ export interface IHttpRequest {
     headers?: IHttpHeaders;
     query?: IHttpQueryParameters;
     cookies?: Array<any>;
+    simple?: boolean;
     resolveWithFullResponse?: boolean;
     gzip?: boolean;
 }

--- a/packages/http-api/src/request-function.ts
+++ b/packages/http-api/src/request-function.ts
@@ -46,7 +46,7 @@ export async function requestFunction(
         headers: request.headers,
         json: request.json,
         gzip: request.gzip,
-        simple: typeof request.simple !== 'undefined' ? request.simple : true,
+        simple: request.simple !== false,
         jar: cookieJar,
         resolveWithFullResponse: true,
     };

--- a/packages/http-api/src/request-function.ts
+++ b/packages/http-api/src/request-function.ts
@@ -46,6 +46,7 @@ export async function requestFunction(
         headers: request.headers,
         json: request.json,
         gzip: request.gzip,
+        simple: typeof request.simple !== 'undefined' ? request.simple : true,
         jar: cookieJar,
         resolveWithFullResponse: true,
     };


### PR DESCRIPTION
https://www.npmjs.com/package/request-promise
By default, http response codes other than 2xx will cause the promise to be rejected. This can be overwritten by setting options.simple = false.