### PR TITLE
WAT-3941 - No timeout displayed in log on waitForRoot call

### DIFF
--- a/packages/web-application/src/web-application.ts
+++ b/packages/web-application/src/web-application.ts
@@ -71,7 +71,7 @@ export class WebApplication extends PluggableModule {
     public root = createElementPath();
 
     static stepLogMessagesDecorator = {
-        waitForRoot(timeout) {
+        waitForRoot(timeout: number = this.WAIT_TIMEOUT) {
             return `Waiting for root element for ${timeout}`;
         },
         waitForExist(xpath, timeout: number = this.WAIT_TIMEOUT) {


### PR DESCRIPTION
### Problem

No timeout displayed in log when waitForRoot called with default parameters

### Steps to reproduce

Call waitForRoot without default timeout overriding

### Actual result

Message in log:
`Waiting for root element for undefined`

### Expected result

`Waiting for root element for 45000`